### PR TITLE
Fix an account number argument to string type

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ sbi.close()
 from bank.mizuho import Mizuho
 
 mizuho = Mizuho().login("<ユーザID>", "<パスワード>")
-b = mizuho.get_balance(7654321)
+b = mizuho.get_balance("7654321")
 print(f"口座番号, 店舗, 残高, 口座タイプ")
 print(f"{b.account_number}, {b.branch_name}, {b.value}, {b.deposit_type}")
 

--- a/bank/__init__.py
+++ b/bank/__init__.py
@@ -16,9 +16,9 @@ class Bank(Base, metaclass=ABCMeta):
         self.driver.quit()
 
     @abstractmethod
-    def get_balance(self, account_number: int) -> Balance:
+    def get_balance(self, account_number: str) -> Balance:
         raise NotImplementedError()
 
     @abstractmethod
-    def get_transaction_history(self, account_number: int) -> list[Transaction]:
+    def get_transaction_history(self, account_number: str) -> list[Transaction]:
         raise NotImplementedError()

--- a/bank/mizuho/__init__.py
+++ b/bank/mizuho/__init__.py
@@ -35,7 +35,7 @@ class Mizuho(Bank, ABC):
         return self
 
 
-    def get_balance(self, account_number: int) -> Balance:
+    def get_balance(self, account_number: str) -> Balance:
         self.driver.find_element(By.ID, 'MB_R011N030').click()
         # When there is the account select box
         try:
@@ -44,7 +44,7 @@ class Mizuho(Bank, ABC):
             # skip header
             next(tr)
             for num, t in enumerate(tr):
-                if t.find_elements(By.TAG_NAME, "span")[2].text == str(account_number):
+                if t.find_elements(By.TAG_NAME, "span")[2].text == account_number:
                     t.find_element(By.NAME, f"chkAccChkBx_{str(num).zfill(3)}").click()
                     break
             self.driver.find_element(By.XPATH, '//*[@id="main"]/section/input').click()
@@ -66,5 +66,5 @@ class Mizuho(Bank, ABC):
         )
 
 
-    def get_transaction_history(self, account_number: int) -> list[Transaction]:
+    def get_transaction_history(self, account_number: str) -> list[Transaction]:
         raise NotImplementedError()

--- a/bank/model.py
+++ b/bank/model.py
@@ -37,12 +37,12 @@ class Transaction:
 
 
 class Balance:
-    account_number: int
+    account_number: str
     deposit_type: DepositType
     branch_name: str
     value: float
 
-    def __init__(self, account_number: int, deposit_type: DepositType, branch_name: str, value: float):
+    def __init__(self, account_number: str, deposit_type: DepositType, branch_name: str, value: float):
         self.account_number = account_number
         self.deposit_type = deposit_type
         self.branch_name = branch_name


### PR DESCRIPTION
### Description

* About bank, when an account number starts 0, it cannot get balance. So it fixes the type to string.