### PR TITLE
Add wait loading to sbi net bank after login

### DIFF
--- a/acctf/bank/sbi/__init__.py
+++ b/acctf/bank/sbi/__init__.py
@@ -92,6 +92,8 @@ class SBI(Bank, ABC):
         if account_number != "" and account_number is not None:
             self.account_number = account_number
 
+        self.wait_loading(By.CLASS_NAME, "loading-Server")
+
         details = 'm-icon-ps_details'
         elem = self.find_element_to_be_clickable(By.CLASS_NAME, details)
         elem.click()

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ long_description = (here / "README.md").read_text(encoding="utf-8")
 
 setup(
     name="acctf",
-    version="0.4.2",
+    version="0.4.3",
     description="library that scrapes the data from an account such as securities, bank",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
### Description

* An error occurs after sbi net bank logins. So I add `wait_loading` before `m-icon-ps_details` clicked.
```console
  File "/usr/local/lib/python3.11/site-packages/acctf/bank/sbi/__init__.py", line 97, in get_transaction_history
    elem.click()
  File "/usr/local/lib/python3.11/site-packages/selenium/webdriver/remote/webelement.py", line 94, in click
    self._execute(Command.CLICK_ELEMENT)
  File "/usr/local/lib/python3.11/site-packages/selenium/webdriver/remote/webelement.py", line 395, in _execute
    return self._parent.execute(command, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/selenium/webdriver/remote/webdriver.py", line 347, in execute
    self.error_handler.check_response(response)
  File "/usr/local/lib/python3.11/site-packages/selenium/webdriver/remote/errorhandler.py", line 229, in check_response
    raise exception_class(message, screen, stacktrace)
selenium.common.exceptions.ElementClickInterceptedException: Message: Element <span class="m-icon-ps_details"> is not clickable at point (477,31) because another element <div class="loading-Server"> obscures it
Stacktrace:
RemoteError@chrome://remote/content/shared/RemoteError.sys.mjs:8:8
WebDriverError@chrome://remote/content/shared/webdriver/Errors.sys.mjs:187:5
ElementClickInterceptedError@chrome://remote/content/shared/webdriver/Errors.sys.mjs:331:5
webdriverClickElement@chrome://remote/content/marionette/interaction.sys.mjs:162:11
interaction.clickElement@chrome://remote/content/marionette/interaction.sys.mjs:121:11
clickElement@chrome://remote/content/marionette/actors/MarionetteCommandsChild.sys.mjs:214:29
receiveMessage@chrome://remote/content/marionette/actors/MarionetteCommandsChild.sys.mjs:97:31
```