### PR TITLE
fix(wealthnavi): adapt login flow and locators after Playwright migration

### DIFF
--- a/acctf/other/wealthnavi/__init__.py
+++ b/acctf/other/wealthnavi/__init__.py
@@ -17,8 +17,8 @@ class WealthNavi(Base):
 
     def login(self, user_id: str, password: str, totp: str | None = None):
         self.find_element('#username').fill(user_id)
+        self.page.locator('[name="action"]').click()
         self.page.locator('#password').fill(password)
-
         self.page.locator('[name="action"]').nth(1).click()
 
         if totp is not None:

--- a/acctf/other/wealthnavi/__init__.py
+++ b/acctf/other/wealthnavi/__init__.py
@@ -17,7 +17,7 @@ class WealthNavi(Base):
 
     def login(self, user_id: str, password: str, totp: str | None = None):
         self.find_element('#username').fill(user_id)
-        self.page.locator('[name="action"]').click()
+        self.page.get_by_role("button", name="ID・パスワードでログイン").click()
         self.page.locator('#password').fill(password)
         self.page.locator('[name="action"]').nth(1).click()
 

--- a/acctf/other/wealthnavi/__init__.py
+++ b/acctf/other/wealthnavi/__init__.py
@@ -19,7 +19,7 @@ class WealthNavi(Base):
         self.find_element('#username').fill(user_id)
         self.page.get_by_role("button", name="ID・パスワードでログイン").click()
         self.page.locator('#password').fill(password)
-        self.page.locator('[name="action"]').nth(1).click()
+        self.page.get_by_role("button", name="ログイン").click()
 
         if totp is not None:
             self.find_element('#code').fill(str(get_code(totp)))

--- a/acctf/other/wealthnavi/__init__.py
+++ b/acctf/other/wealthnavi/__init__.py
@@ -32,8 +32,8 @@ class WealthNavi(Base):
 
     def get_valuation(self) -> list[Asset]:
         self.page.set_viewport_size({"width": 1024, "height": 600})
-        self.find_element('a:has-text("ポートフォリオ")').click()
-        self.page.wait_for_load_state("networkidle")
+        self.page.locator('#menu-portfolio a').click()
+        self.find_element('#assets-class-data')
 
         html = self.page.content().encode('utf-8')
         soup = BeautifulSoup(html, 'html.parser')

--- a/acctf/other/wealthnavi/__init__.py
+++ b/acctf/other/wealthnavi/__init__.py
@@ -28,7 +28,7 @@ class WealthNavi(Base):
         return self
 
     def logout(self):
-        self.page.locator('.logout-submit').click()
+        self.page.locator('.logout-submit').first.click()
 
     def get_valuation(self) -> list[Asset]:
         self.page.set_viewport_size({"width": 1024, "height": 600})

--- a/acctf/other/wealthnavi/__init__.py
+++ b/acctf/other/wealthnavi/__init__.py
@@ -33,6 +33,7 @@ class WealthNavi(Base):
     def get_valuation(self) -> list[Asset]:
         self.page.set_viewport_size({"width": 1024, "height": 600})
         self.find_element('a:has-text("ポートフォリオ")').click()
+        self.page.wait_for_load_state("networkidle")
 
         html = self.page.content().encode('utf-8')
         soup = BeautifulSoup(html, 'html.parser')


### PR DESCRIPTION
## Summary
#42 (to-playwright) で Selenium → Playwright に移行した後、WealthNavi スクレイパーを実機テストして発覚した複数の不具合を修正。

## Changes

### Login の二段階入力UI対応
WealthNavi のログイン画面が「ID入力 → 「ID・パスワードでログイン」 → パスワード入力 → 「ログイン」」の二段階フローに変更されているため、`login()` を順序通りクリック・入力するよう修正。

### Playwright strict mode 違反の解消
- 「ID・パスワードでログイン」ボタンが `[name=\"action\"]` で4要素マッチしてしまう (隠しsubmit / 可視ボタン / hidden input / パスキーボタン) → `get_by_role(\"button\", name=\"ID・パスワードでログイン\")` で role ベース locator に切り替え (隠し要素は accessibility tree から除外される)
- 「ログイン」ボタンも同様に `get_by_role(\"button\", name=\"ログイン\")`
- `logout()` の `.logout-submit` が header と navigation menu の2要素にマッチ → `.first.click()` で先頭要素のみ対象に

### `get_valuation()` で空配列が返る問題の修正
- 当初 `wait_for_load_state(\"networkidle\")` を使ったが、WealthNavi は Datadog RUM / GTM など外部スクリプトによる継続的な通信があり networkidle が成立せず timeout してしまう
- 対策として、テーブル要素自体の出現を直接待つ方式 (`find_element('#assets-class-data')`) に変更
- ナビゲーション locator も `a:has-text(\"ポートフォリオ\")` から `#menu-portfolio a` に specific 化

## Test plan
- [x] `cd examples && docker build --platform linux/arm64 -t acctf-example .` が成功する
- [x] `docker run --rm --platform linux/arm64 -e ACCTF_USER_ID=... -e ACCTF_PASSWORD=... -e ACCTF_TOTP=... acctf-example` でログイン → ポートフォリオ取得 → ログアウトまで例外なく完走
- [x] 出力に各資産クラス (米国株(VTI) / 日欧株(VEA) / 新興国株(VWO) / 債券(AGG) / 金(GLD) / 金(IAU) / 不動産(IYR) / 現金) のデータ行が含まれる