### PR TITLE
Fix SBI Net Bank scraper for renewed UI (login, balance, transaction history)

### DIFF
--- a/acctf/bank/model.py
+++ b/acctf/bank/model.py
@@ -49,9 +49,18 @@ class Balance:
     deposit_type: DepositType
     branch_name: str
     value: float
+    account_name: str
 
-    def __init__(self, account_number: str, deposit_type: DepositType, branch_name: str, value: float):
+    def __init__(
+        self,
+        account_number: str,
+        deposit_type: DepositType,
+        branch_name: str,
+        value: float,
+        account_name: str = "",
+    ):
         self.account_number = account_number
         self.deposit_type = deposit_type
         self.branch_name = branch_name
         self.value = value
+        self.account_name = account_name

--- a/acctf/bank/sbi/__init__.py
+++ b/acctf/bank/sbi/__init__.py
@@ -20,12 +20,13 @@ class SBI(Bank, ABC):
 
     def __init__(self, page: Page, timeout: int = 30000):
         super().__init__(page=page, timeout=timeout)
-        self.page.goto('https://www.netbk.co.jp/contents/pages/wpl010101/i010101CT/DI01010210')
+        self.page.goto('https://www.netbk.co.jp/contents/pages/wpl010101E/i010101CT/DI01010240')
 
     def login(self, user_id: str, password: str, totp: str | None = None):
-        self.find_element('#userNameNewLogin').fill(user_id)
-        self.find_element('#loginPwdSet').fill(password)
-        self.page.locator('//nb-button-login/button').click()
+        self.find_element('input[name="username"]').fill(user_id)
+        self.find_element('ul.ren_btn._ren_main a._ren_fill_blue').click()
+        self.find_element('input#loginPwd').fill(password)
+        self.find_element('ul._login_spec button._ren_fill_blue').click()
         self.page.set_viewport_size({"width": 1024, "height": 3480})
         time.sleep(1)
         self._get_account_info()

--- a/acctf/bank/sbi/__init__.py
+++ b/acctf/bank/sbi/__init__.py
@@ -40,7 +40,7 @@ class SBI(Bank, ABC):
         if account_number != "" and account_number is not None:
             self.account_number = account_number
 
-        self.find_element_to_be_clickable('.m-icon-ps_balance').click()
+        self.page.goto('https://www.netbk.co.jp/contents/pages/wpl020101A/i020101CT/DI02010105')
 
         self.wait_loading('.loadingServer')
 
@@ -102,7 +102,7 @@ class SBI(Bank, ABC):
 
         self.wait_loading('.loading-Server')
 
-        self.find_element_to_be_clickable('.m-icon-ps_details').click()
+        self.page.goto('https://www.netbk.co.jp/contents/pages/wpl020201/i020201CT/DI02020100')
 
         self.wait_loading('.loadingServer')
 

--- a/acctf/bank/sbi/__init__.py
+++ b/acctf/bank/sbi/__init__.py
@@ -115,6 +115,9 @@ class SBI(Bank, ABC):
         # 明細の表示
         self._get_transaction(start, end)
 
+        # 「さらに見る」を全展開してから CSV ダウンロード
+        self._expand_all_transactions()
+
         file = ""
         try:
             # 明細のダウンロード
@@ -189,16 +192,27 @@ class SBI(Bank, ABC):
         e.click()
         time.sleep(1)
 
+    def _expand_all_transactions(self) -> None:
+        """「さらに見る」ボタンを表示されている限りクリックし、検索結果を全件展開する。"""
+        max_iterations = 100
+        for _ in range(max_iterations):
+            more_btn = self.page.locator('div.meisai_more a.m-btnDefW-m').filter(visible=True)
+            if more_btn.count() == 0:
+                return
+            more_btn.first.click()
+            time.sleep(1)
+            self.wait_loading('.loadingServer', has_raised=False)
+
     def _download_transaction(self, download_directory: Path) -> str:
         e = self.find_element('.m-boxError.ng-star-inserted', has_raised=False)
         if e is not None:
             return ""
 
         with self.page.expect_download(timeout=self.timeout) as dl_info:
-            # ダウンロード
-            self.find_element('//section/div/div[1]/nav/ul/li[2]/ul/li[2]').click()
+            # ダウンロードメニュー展開
+            self.find_element('a._download').click()
             # CSV
-            self.find_element('//span[contains(text(), "CSV")]').click()
+            self.find_element('a.details-iconExcel').click()
 
         download = dl_info.value
         dest = str(Path(download_directory) / download.suggested_filename)

--- a/acctf/bank/sbi/__init__.py
+++ b/acctf/bank/sbi/__init__.py
@@ -3,14 +3,13 @@ from pathlib import Path
 import time
 from abc import ABC
 from datetime import date, datetime
-from io import StringIO
 
 import pandas as pd
 from bs4 import BeautifulSoup
 from playwright.sync_api import Page
 
 from acctf.bank import Bank, Balance, Transaction
-from acctf.bank.model import str_to_deposit_type, CurrencyType
+from acctf.bank.model import DepositType, str_to_deposit_type, CurrencyType
 from acctf.bank.sbi.model import AccountName
 
 
@@ -46,27 +45,109 @@ class SBI(Bank, ABC):
 
         html = self.page.content().encode('utf-8')
         soup = BeautifulSoup(html, 'html.parser')
-        table = soup.find_all("table")
-        if table is None or len(table) == 0:
-            return []
 
-        df = pd.read_html(StringIO(str(table)))
-        ret = []
-        for d in df:
-            if d.columns[-1] == "取引メニュー" and d.columns[-2] != "円換算額":
-                dtype = str_to_deposit_type("普通")
-                if d.columns[0] != "口座":
-                    dtype = str_to_deposit_type("ハイブリッド")
-                ret.append(
-                    Balance(
-                        account_number=self.account_number,
-                        deposit_type=dtype,
-                        branch_name=self.branch_name,
-                        value=float(d["残高"][0].replace(",", "").replace("円", ""))
-                    )
-                )
+        ret: list[Balance] = []
+        for item in soup.select('li.m-zandaka-item'):
+            classes = item.get('class') or []
+            # SBI証券保有資産評価は預金口座ではないため除外
+            if 'm-sbisec-item' in classes:
+                continue
+
+            if 'm-zandaka-item-hybrid' in classes:
+                dtype = self._safe_deposit_type("ハイブリッド")
+                ret.extend(self._parse_hybrid_balance(item, dtype))
+            elif 'm-zandaka-gaika' in classes:
+                dtype = self._safe_deposit_type("普通")
+                ret.extend(self._parse_foreign_balance(item, dtype))
+            else:
+                dtype = self._safe_deposit_type("普通")
+                ret.extend(self._parse_jpy_balance(item, dtype))
 
         return ret
+
+    @staticmethod
+    def _safe_deposit_type(label: str) -> DepositType:
+        try:
+            return str_to_deposit_type(label)
+        except ValueError:
+            return DepositType.ordinary
+
+    @staticmethod
+    def _parse_amount(text: str) -> float | None:
+        cleaned = text.replace(",", "").replace("円", "").strip()
+        for token in cleaned.split():
+            try:
+                return float(token)
+            except ValueError:
+                continue
+        try:
+            return float(cleaned)
+        except ValueError:
+            return None
+
+    def _parse_jpy_balance(self, item, dtype: DepositType) -> list[Balance]:
+        out: list[Balance] = []
+        for row in item.select('table tbody tr'):
+            bal_cell = row.find(attrs={"data-label": "残高"})
+            if bal_cell is None:
+                continue
+            val = self._parse_amount(bal_cell.get_text())
+            if val is None:
+                continue
+            name_cell = row.find('th', class_='m-zandaka-item-detail-name')
+            if name_cell is None:
+                name_cell = row.find(attrs={"data-label": "口座"})
+            name = name_cell.get_text(strip=True) if name_cell else "代表口座"
+            out.append(Balance(
+                account_number=self.account_number,
+                deposit_type=dtype,
+                branch_name=self.branch_name,
+                value=val,
+                account_name=name,
+            ))
+        return out
+
+    def _parse_hybrid_balance(self, item, dtype: DepositType) -> list[Balance]:
+        out: list[Balance] = []
+        for row in item.select('table tbody tr'):
+            bal_cell = row.find(attrs={"data-label": "残高"})
+            if bal_cell is None:
+                continue
+            val = self._parse_amount(bal_cell.get_text())
+            if val is None:
+                continue
+            out.append(Balance(
+                account_number=self.account_number,
+                deposit_type=dtype,
+                branch_name=self.branch_name,
+                value=val,
+                account_name="代表口座",
+            ))
+        return out
+
+    def _parse_foreign_balance(self, item, dtype: DepositType) -> list[Balance]:
+        out: list[Balance] = []
+        for table in item.find_all('table'):
+            h3 = table.find_previous('h3')
+            currency_name = h3.get_text(strip=True) if h3 else ""
+            for row in table.select('tbody tr'):
+                bal_cell = row.find(attrs={"data-label": "残高"})
+                if bal_cell is None:
+                    continue
+                val = self._parse_amount(bal_cell.get_text())
+                if val is None:
+                    continue
+                name_cell = row.find(attrs={"data-label": "口座"})
+                row_name = name_cell.get_text(strip=True) if name_cell else "代表口座"
+                name = f"{currency_name} {row_name}".strip() if currency_name else row_name
+                out.append(Balance(
+                    account_number=self.account_number,
+                    deposit_type=dtype,
+                    branch_name=self.branch_name,
+                    value=val,
+                    account_name=name,
+                ))
+        return out
 
     def get_transaction_history(
         self,

--- a/acctf/bank/sbi/__init__.py
+++ b/acctf/bank/sbi/__init__.py
@@ -1,4 +1,5 @@
 import os
+import re
 from pathlib import Path
 import time
 from abc import ABC
@@ -72,16 +73,15 @@ class SBI(Bank, ABC):
         except ValueError:
             return DepositType.ordinary
 
-    @staticmethod
-    def _parse_amount(text: str) -> float | None:
-        cleaned = text.replace(",", "").replace("円", "").strip()
-        for token in cleaned.split():
-            try:
-                return float(token)
-            except ValueError:
-                continue
+    _AMOUNT_PATTERN = re.compile(r'-?[\d,]+(?:\.\d+)?')
+
+    @classmethod
+    def _parse_amount(cls, text: str) -> float | None:
+        m = cls._AMOUNT_PATTERN.search(text)
+        if m is None:
+            return None
         try:
-            return float(cleaned)
+            return float(m.group(0).replace(",", ""))
         except ValueError:
             return None
 
@@ -137,7 +137,9 @@ class SBI(Bank, ABC):
                 val = self._parse_amount(bal_cell.get_text())
                 if val is None:
                     continue
-                name_cell = row.find(attrs={"data-label": "口座"})
+                name_cell = row.find('th', class_='m-zandaka-item-detail-name')
+                if name_cell is None:
+                    name_cell = row.find(attrs={"data-label": "口座"})
                 row_name = name_cell.get_text(strip=True) if name_cell else "代表口座"
                 name = f"{currency_name} {row_name}".strip() if currency_name else row_name
                 out.append(Balance(

--- a/acctf/bank/sbi/__init__.py
+++ b/acctf/bank/sbi/__init__.py
@@ -252,17 +252,17 @@ class SBI(Bank, ABC):
             # 終了日
             self.find_elements('//p[1]/nb-simple-select/span/span[2]').nth(1).click()
             self.find_element('.ui-menu-item.ng-tns-c8-10.ng-star-inserted')
-            e = self.find_elements(f'//li[contains(text(), " {end.year}年")]').nth(1)
+            e = self.page.locator(f'//li[contains(text(), " {end.year}年")]').filter(visible=True).first
             e.hover()
             e.click()
             self.find_elements('//p[2]/nb-simple-select/span/span[2]').nth(1).click()
             self.find_element('.ui-menu-item.ng-tns-c8-11.ng-star-inserted')
-            e = self.find_elements(f'//li[contains(text(), " {end.month}月")]').nth(1)
+            e = self.page.locator(f'//li[contains(text(), " {end.month}月")]').filter(visible=True).first
             e.hover()
             e.click()
             self.find_elements('//p[3]/nb-simple-select/span/span[2]').nth(1).click()
             self.find_element('.ui-menu-item.ng-tns-c8-12.ng-star-inserted')
-            e = self.find_elements(f'//li[contains(text(), " {end.day}日")]').nth(1)
+            e = self.page.locator(f'//li[contains(text(), " {end.day}日")]').filter(visible=True).first
             e.hover()
             e.click()
         else:


### PR DESCRIPTION
## Summary

- 住信SBIネット銀行の刷新後 UI に追従するため、ログイン・残高取得・入出金履歴取得のフローを全面的に修正。
- `Balance` に optional `account_name: str = \"\"` を追加し、SBI のみ目的別口座を口座名付きで返せるようにした (他銀行は kwargs 呼び出しのため後方互換)。
- 残高取得を BeautifulSoup ベースに書き直し、`m-zandaka-item` セクション (円普通預金 / SBIハイブリッド預金 / 外貨普通預金) を全件抽出。SBI証券保有資産評価 (`m-sbisec-item`) は対象外。
- 数値抽出は regex (`-?[\d,]+(?:\.\d+)?`) ベースに統一。`739.30USD` のような数値+単位連結セルにも対応。

### 主な変更点

- **ログイン**: 2 段階ログイン (`input[name=\"username\"]` → `input#loginPwd`) に対応 (`993a5b8` Fix login)
- **ナビゲーション**: 折りたたみメニューのアイコンクリック方式を廃し、`page.goto` による直接 URL 遷移に統一 (`776d4c6`)
- **入出金履歴の終了日選択**: Angular jQuery UI selectmenu の隠れた `<li>` を避け、`filter(visible=True).first` で可視要素のみ拾う (`a332d2c`)
- **「さらに見る」展開**: CSV ダウンロード前に `_expand_all_transactions` で全件展開。CSV ダウンロードボタンも class ベースセレクタ (`a._download` / `a.details-iconExcel`) に置換 (`49faae0`)
- **残高取得**: 目的別口座と外貨を含む全口座を返す。`Balance.account_name` に口座名を格納 (`63a7617`, `136b5dd`)

## Test plan

- [x] Docker / `uv run` で `examples/main.py` を実行し、`get_balance` が以下を返すことを確認:
- [x] `get_transaction_history` で代表口座 (JPY) の任意期間 CSV が取得できる
- [x] 「さらに見る」が表示される長期間でも全件取得できる